### PR TITLE
Make August meeting 1 day earlier

### DIFF
--- a/agendas/2022/2022-08-17.md
+++ b/agendas/2022/2022-08-17.md
@@ -75,8 +75,8 @@ To read about the purpose of this subcommittee, please see
 This is an open meeting in which anyone in the GraphQL community may attend.
 
 - **Date & Time**:
-  [August 18th 2022 15:00 - 17:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=8&day=18&hour=15&min=0&sec=0&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
-  - **Note**: This meeting is a week later than usual.
+  [August 17th 2022 15:00 - 17:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=8&day=17&hour=15&min=0&sec=0&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+  - **Note**: This meeting is 6 days later than usual.
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,


### PR DESCRIPTION
Turns out 18th August conflicts with another GraphQL event so many of the attendees couldn't make it; I've moved it a day earlier instead.