### PR TITLE
Change meeting time to 6pm CE(S)T

### DIFF
--- a/agendas/2024/11-Nov/14-week-2.md
+++ b/agendas/2024/11-Nov/14-week-2.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [November 14, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241114T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [November 14, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241114T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2024/11-Nov/21-week-3.md
+++ b/agendas/2024/11-Nov/21-week-3.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [November 21, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241121T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [November 21, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241121T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2024/11-Nov/28-week-4.md
+++ b/agendas/2024/11-Nov/28-week-4.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [November 28, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241128T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [November 28, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241128T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2024/12-Dec/05-primary.md
+++ b/agendas/2024/12-Dec/05-primary.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [December 5, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241205T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [December 5, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241205T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2024/12-Dec/12-week-2.md
+++ b/agendas/2024/12-Dec/12-week-2.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [December 12, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241212T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [December 12, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241212T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2024/12-Dec/19-week-3.md
+++ b/agendas/2024/12-Dec/19-week-3.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [December 19, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241219T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [December 19, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241219T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2024/12-Dec/26-week-4.md
+++ b/agendas/2024/12-Dec/26-week-4.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [December 26, 2024, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20241226T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [December 26, 2024, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20241226T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/01-Jan/02-primary.md
+++ b/agendas/2025/01-Jan/02-primary.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [January 2, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250102T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [January 2, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250102T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/01-Jan/09-week-2.md
+++ b/agendas/2025/01-Jan/09-week-2.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [January 9, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250109T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [January 9, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250109T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/01-Jan/16-week-3.md
+++ b/agendas/2025/01-Jan/16-week-3.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [January 16, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250116T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [January 16, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250116T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/01-Jan/23-week-4.md
+++ b/agendas/2025/01-Jan/23-week-4.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [January 23, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250123T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [January 23, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250123T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/01-Jan/30-week-5.md
+++ b/agendas/2025/01-Jan/30-week-5.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [January 30, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250130T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [January 30, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250130T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/02-Feb/06-primary.md
+++ b/agendas/2025/02-Feb/06-primary.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [February 6, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250206T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [February 6, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250206T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/02-Feb/13-week-2.md
+++ b/agendas/2025/02-Feb/13-week-2.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [February 13, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250213T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [February 13, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250213T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/02-Feb/20-week-3.md
+++ b/agendas/2025/02-Feb/20-week-3.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [February 20, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250220T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [February 20, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250220T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2025/02-Feb/27-week-4.md
+++ b/agendas/2025/02-Feb/27-week-4.md
@@ -81,7 +81,7 @@ Schemas Specification" project.
 The first meeting each month is the primary monthly meeting; to enable a greater
 cadence of progress we also have weekly meetings which tend to be more informal.
 
-- **Date & Time**: [February 27, 2025, 4:00 – 5:00 PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250227T160000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+- **Date & Time**: [February 27, 2025, 6:00 – 7:00 PM GMT+1](https://www.timeanddate.com/worldclock/converter.html?iso=20250227T170000&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "cspell": "5.9.1",
     "prettier": "^2.6.2",
-    "wgutils": "^0.1.3"
+    "wgutils": "^0.1.8"
   },
   "prettier": {
     "proseWrap": "always",

--- a/wg.config.js
+++ b/wg.config.js
@@ -8,11 +8,11 @@ const config = {
   - _Password:_ composite`,
   liveNotesUrl:
     "https://docs.google.com/document/d/1hJO6U7daYvcNcQ3FBKnh3v4R256ers6M8IGyqRpY_kE/edit?usp=sharing",
-  timezone: "UTC",
+  timezone: "Europe/Berlin",
   frequency: "weekly",
   primaryN: 1,
   weekday: "Th", // M, Tu, W, Th, F, Sa, Su
-  time: "16:00-17:00", // 24-hour clock, range
+  time: "18:00-19:00", // 24-hour clock, range
   attendeesTemplate: `\
 | Name             | GitHub        | Organization       | Location              |
 | :--------------- | :------------ | :----------------- | :-------------------- |


### PR DESCRIPTION
Uses the `Europe/Berlin` timezone to represent CET/CEST as appropriate. Applies to the next meeting onwards.

cc @martijnwalraven @michaelstaib 