### PR TITLE
Auto-merge approved agenda additions

### DIFF
--- a/.github/workflows/wgutils-automerge.yml
+++ b/.github/workflows/wgutils-automerge.yml
@@ -1,0 +1,52 @@
+name: Agenda auto-merge
+
+on:
+  pull_request_target:
+    types: [synchronize, opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: read
+
+jobs:
+  validate-and-merge:
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      # SECURITY: it's critical we do not check out the source pull request!
+      - name: Checkout the main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      # We need wgutils to be installed
+      - run: yarn install
+
+      - name: Wait for checks to pass
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Give 15 seconds for any checks to register
+          sleep 15
+
+          # Wait for checks to pass
+          gh pr checks ${{ github.event.pull_request.number }} --fail-fast --watch --required 2>&1 || true
+          # Now get the result in JSON
+          CHECKS_OUTPUT="$(gh pr checks ${{ github.event.pull_request.number }} --required --json bucket --jq 'map(.bucket == "pass") | all' 2>&1 || true)"
+
+          if [[ "$CHECKS_OUTPUT" == "true" ]]; then
+            echo "$CHECKS_OUTPUT"
+          else
+            echo "PR state failed? $CHECKS_OUTPUT"
+            exit 1
+          fi
+
+      - name: Automerge if wgutils approves
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if yarn wgutils can-automerge "${{ github.event.pull_request.number }}" "${{ github.event.pull_request.head.sha }}"; then
+            gh pr merge "${{ github.event.pull_request.number }}" --squash --auto --match-head-commit "${{ github.event.pull_request.head.sha }}"
+          fi

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "cspell": "5.9.1",
     "prettier": "^2.6.2",
-    "wgutils": "^0.1.8"
+    "wgutils": "^1.2.1"
   },
   "prettier": {
     "proseWrap": "always",


### PR DESCRIPTION
This PR makes it so that if someone raises a PR to add themselves or agenda topics to an agenda and their PR doesn't involve any deletions and they've passed the EasyCLA check then their change will be automatically merged. Should help streamline the attendance procedure and avoid git conflicts.