### PR TITLE
add mark to 18-week-3.md

### DIFF
--- a/agendas/2025/09-Sep/18-week-3.md
+++ b/agendas/2025/09-Sep/18-week-3.md
@@ -101,6 +101,7 @@ cadence of progress we also have weekly meetings which tend to be more informal.
 <!-- prettier-ignore -->
 | Name             | GitHub        | Organization       | Location              |
 | :--------------- | :------------ | :----------------- | :-------------------- |
+| Mark Larah       | @magicmark    | Yelp               | Austin, TX, US        |
 
 
 ## Agenda
@@ -115,3 +116,4 @@ cadence of progress we also have weekly meetings which tend to be more informal.
 1. Determine volunteers for note taking (1m, Host)
 1. Review agenda (2m, Host)
 1. Check for [ready for review agenda items](https://github.com/graphql/composite-schemas-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)
+1. `@defer`ing fields (where possible) by default vs @splitSchema (15m, Mark)


### PR DESCRIPTION
👋 joining to discuss https://github.com/graphql/composite-schemas-spec/issues/198

To guide the discussion, there's 2 options that have been discussed:

1. individually `@defer` all "non-immediately" required fields in a selection set
  - (this is what hot chocolate has implemented) 
1. a new `@internalDefer` (or similar) directive to let schema authors provide a hint to the query planner to manually query parts of a selection set in parallel
  - (this is what Apollo has previously implemented internally)